### PR TITLE
Update registry.py

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -3,5 +3,25 @@
 registry = [
     ("Hydrogen.txt", 0.0000899, ["H", "H2", "Hydrogen", "Водород", "Wasserstoff", "Hydrogène", "Idrogeno", "Hidrógeno"] ),
     ("Helium.txt"  , 0.0001753, ["He", "Helium", "Гелий", "Hélium", "Elio", "Helio"] ),
-    ("Berillium.txt"  , 1.848, ["Be", "Berillium", "Бериллий", "Béryllium", "Berilio", "Berillio"] )
+    ("Berillium.txt"  , 1.848, ["Be", "Berillium", "Бериллий", "Béryllium", "Berilio", "Berillio"] ),
+    ("Nitrogen.txt" , 0.001251, ["N", "Nitrogen", "Азот", "Azote", "Nitrógeno", "azoto"]),
+    ("Oxygen.txt" , 1.141, ["O", "Oxygen", "Кислород", "Oxygène", "Oxígeno", "Ossigeno"]),
+    ("Neon.txt" , 0.00090035, ["Ne", "Neon", "Неон", "Néon", "Neón"]),
+    ("Aluminum.txt" , 2.6989, ["Al", "Aluminum", "Алюминий", "Aluminium", "Aluminio", "Alluminio"]),
+    ("Silicon.txt" , 2.33, ["Si", "Silicon", "Кремний", "Silicium", "Silicio"]),
+    ("Argon.txt" , 0.001784, ["Ar", "Argon", "Аргон", "Argón"]),
+    ("Titanium.txt" , 4.54, ["Ti", "Titanium", "Титан", "Titane", "Titanio"]),
+    ("Iron.txt" , 7.874, ["Fe", "Iron", "Железо", "Fer", "Hierro", "Ferro"]),
+    ("Copper.txt" , 8.92, ["Cu", "Copper", "Медь", "Cuivre", "Cobre", "Rame"]),
+    ("Germanium.txt" , 5.323, ["Ge", "Germanium", "Германий", "Germanio"]),
+    ("Krypton.txt" , 0.003749, ["Kr", "Krypton", "Криптон", "Criptón", "Cripto"]),
+    ("Molybdenum.txt" , 10.22, ["Mo", "Molybdenum", "Молибден", "Molybdène", "Molibdeno"]),
+    ("Silver.txt" , 10.5, ["Ag", "Silver", "Серебро", "Argent", "Plata", "Argento"]),
+    ("Xenon.txt" , 0.005894, ["Xe", "Xenon", "Ксенон", "Xénon", "Xenón", "Xeno"]),
+    ("Gadolinium.txt" , 7.9, ["Gd", "Gadolinium", "Gadolinio"]),
+    ("Tungsten.txt" , 19.25, ["W", "Tungsten", "Вольфрам", "Tungstène", "Tungsteno"]),
+    ("Platinum.txt" , 21.09, ["Pt", "Platinum", "Платина", "Platine", "Platino"]),
+    ("Gold.txt" , 19.3, ["Au", "Gold", "Золото", "Or", "Oro"]),
+    ("Lead.txt" , 11.3415, ["Pb", "Lead", "Свинец", "Plomb", "Plomo", "Piombo"]),
+    ("Uranium.txt" , 19.05, ["U", "Uranium", "Уран", "Urane", "Uranio"])
 ]


### PR DESCRIPTION
"Neon" in englsh is spelled the same as in italian
"Silicio" in italian is the same as in spanish
"Argon" in eng = in french = in italian
"Titanio" in spanish = in italian
"Germanio" in spanish = in italian
"Krypton" in eng = in french
"Molibdeno" in spanish = in italian
"Gadolinium" in eng = in french, "Gadolinio" in spanish = in italian
"Tungsteno" in spanish = in italian
"Platino" in spanish = in italian
"Oro" in spanish = in italian
"Uranio" in spanish = in italian