### PR TITLE
Redo total_stopping_power with interp1d

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Make a pull request into master (development branch will appear soon).
 
 ## Running plots
 
-```python
+```bash
 python -m pyrange.plots.test_plot_1
+python -m pyrange.plots.test_plot_2 He "Water"
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Python module to calculate range and stopping power for protons in different materials.
 
 The module makes interpolation over tables provided bu National Institute of Standards and Technology.
-Stopping power calculation is donw with cubic spline, while ranges uses simple cubic interpolation.
 
 **Proton tables:** https://physics.nist.gov/PhysRefData/Star/Text/PSTAR.html
 

--- a/pyrange/plots/test_plot_1.py
+++ b/pyrange/plots/test_plot_1.py
@@ -2,13 +2,19 @@ import pyrange
 import matplotlib.pyplot as plt
 import random
 import numpy as np
+import argparse
 
 '''
 plots NIST data together with interpolating function for 3 random materials 
 '''
 
-mat_tuples = random.sample(pyrange.registry, k=3)
-materials = [pyrange.material(tup.names[0]) for tup in mat_tuples]
+# read materials from the arguments
+parser = argparse.ArgumentParser(description='does stuff')
+parser.add_argument('materials', type=str, nargs='*', help='materials for the plot')
+args = parser.parse_args()
+
+random_mat_names = [tup.names[0] for tup in random.sample(pyrange.registry, k=3)]
+materials = [pyrange.material(mat_name) for mat_name in (args.materials if len(args.materials) else random_mat_names)]
 
 variables = lambda material: ((material.csda_range, material.table['csda_range'], 'csda_range'),
 (material.projected_range, material.table['projected_range'], 'projected_range'),
@@ -22,5 +28,5 @@ for material in materials:
         y_pred = function(x_pred)
         plt.plot(x,y,'o')
         plt.plot(x_pred,y_pred)
-        plt.title('Interpolation plot\nMaterial: {material.name}\nVariable: {variable_name}')
+        plt.title(f'Interpolation plot\nMaterial: {material.name}\nVariable: {variable_name}')
         plt.show()

--- a/pyrange/plots/test_plot_1.py
+++ b/pyrange/plots/test_plot_1.py
@@ -6,7 +6,7 @@ import argparse
 from functools import reduce
 
 '''
-plots NIST data together with interpolating function for 3 random materials 
+plots NIST data together with interpolating function for selected materials (3 random materials by default)
 '''
 
 # read materials from the arguments

--- a/pyrange/plots/test_plot_1.py
+++ b/pyrange/plots/test_plot_1.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import random
 import numpy as np
 import argparse
+from functools import reduce
 
 '''
 plots NIST data together with interpolating function for 3 random materials 
@@ -21,10 +22,13 @@ variables = lambda material: ((material.csda_range, material.table['csda_range']
 (material.total_stopping_power, material.table['total_stopping_power'], 'total_stopping_power'),
 (material.detour_factor, material.table['detour_factor'], 'detour_factor'))
 
+concat = lambda x,y : np.concatenate((x,y))
+
 for material in materials:
     for (function, y, variable_name) in variables(material):
         x = material.table['kinetic_energy']
-        x_pred = np.linspace(min(x), max(x), 300)
+        linspaces_list = [np.linspace(x[i], x[i+1], 10) for i in range(len(x)-1)]
+        x_pred = reduce(concat,linspaces_list)
         y_pred = function(x_pred)
         plt.plot(x,y,'o')
         plt.plot(x_pred,y_pred)

--- a/pyrange/plots/test_plot_2.py
+++ b/pyrange/plots/test_plot_2.py
@@ -5,7 +5,7 @@ import numpy as np
 import argparse
 
 '''
-leave-one-out for 3 random materials for each variable
+leave-one-out for each variable for selected materials (3 random materials by default)
 '''
 
 # read materials from the arguments
@@ -52,10 +52,10 @@ for material in materials:
     total_stopping_power_pred = ar(total_stopping_power_pred)
     total_stopping_power_true = ar(total_stopping_power_true)
 
-    csda_range_true
     plt.plot(x,(csda_range_pred-csda_range_true)/(csda_range_true+epsilon),'o',label='CSDA range')
     plt.plot(x,(projected_range_pred-projected_range_true)/(projected_range_true+epsilon),'o',label='projected range')
     plt.plot(x,(detour_factor_pred-detour_factor_true)/(detour_factor_true+epsilon),'o',label='detour factor')
+    plt.plot(x,(total_stopping_power_pred-total_stopping_power_true)/(total_stopping_power_true+epsilon),'o',label='total stopping power')
     plt.title(f'Relative error\nMaterial: {material.name}')
     ax = plt.gca()
     ax.legend()

--- a/pyrange/plots/test_plot_2.py
+++ b/pyrange/plots/test_plot_2.py
@@ -34,7 +34,7 @@ for material in materials:
         csda_range_pred.append(material.csda_range(x[i-1])[()])
         projected_range_pred.append(material.projected_range(x[i-1])[()])
         detour_factor_pred.append(material.detour_factor(x[i-1])[()])
-        total_stopping_power_pred.append(material.total_stopping_power(x[i-1]))
+        total_stopping_power_pred.append(material.detour_factor(x[i-1]))
     
 
     csda_range_pred = ar(csda_range_pred)
@@ -50,7 +50,6 @@ for material in materials:
     plt.plot(x,(csda_range_pred-csda_range_true)/(csda_range_true+epsilon),'o',label='CSDA range')
     plt.plot(x,(projected_range_pred-projected_range_true)/(projected_range_true+epsilon),'o',label='projected range')
     plt.plot(x,(detour_factor_pred-detour_factor_true)/(detour_factor_true+epsilon),'o',label='detour factor')
-    plt.plot(x,(total_stopping_power_pred-total_stopping_power_true)/(total_stopping_power_true+epsilon),'o',label='total stopping power')
     plt.title(f'Relative error\nMaterial: {material.name}')
     ax = plt.gca()
     ax.legend()

--- a/pyrange/plots/test_plot_2.py
+++ b/pyrange/plots/test_plot_2.py
@@ -1,14 +1,20 @@
-from .. import pyrange
+import pyrange
 import matplotlib.pyplot as plt
 import random
 import numpy as np
+import argparse
 
 '''
 leave-one-out for 3 random materials for each variable
 '''
 
-mat_tuples = random.sample(pyrange.registry, k=3)
-materials = [pyrange.material(tup.names[0]) for tup in mat_tuples]
+# read materials from the arguments
+parser = argparse.ArgumentParser(description='does stuff')
+parser.add_argument('materials', type=str, nargs='*', help='materials for the plot')
+args = parser.parse_args()
+
+random_mat_names = [tup.names[0] for tup in random.sample(pyrange.registry, k=3)]
+materials = [pyrange.material(mat_name) for mat_name in (args.materials if len(args.materials) else random_mat_names)]
 
 #TODO: rename
 loo = lambda mylist, i: [x for j,x in enumerate(mylist) if j!=i]

--- a/pyrange/plots/test_plot_2.py
+++ b/pyrange/plots/test_plot_2.py
@@ -34,7 +34,7 @@ for material in materials:
         csda_range_pred.append(material.csda_range(x[i-1])[()])
         projected_range_pred.append(material.projected_range(x[i-1])[()])
         detour_factor_pred.append(material.detour_factor(x[i-1])[()])
-        total_stopping_power_pred.append(material.detour_factor(x[i-1]))
+        total_stopping_power_pred.append(material.total_stopping_power(x[i-1]))
     
 
     csda_range_pred = ar(csda_range_pred)

--- a/pyrange/pyrange.py
+++ b/pyrange/pyrange.py
@@ -1,6 +1,4 @@
 from scipy.interpolate import interp1d
-from scipy.interpolate import splrep
-from scipy.interpolate import splev
 import numpy as np
 import re
 import pathlib
@@ -22,6 +20,8 @@ def search(search_string):
             print(tup)
 
 
+
+
 class material:
     """Material class
 
@@ -38,6 +38,7 @@ class material:
     """
     
 
+
     def __init__(self, name, density=None):
         self.name = name
         self.tup = self.find_material(name)
@@ -45,10 +46,10 @@ class material:
         self.is_dummy = (self.tup.filename == "None")
 
         zero_fn = lambda x: np.asarray(x)*0.
-
         self.projected_range = zero_fn
         self.csda_range = zero_fn
         self.detour_factor = zero_fn
+        self.total_stopping_power = zero_fn
 
         self.table = {name:list() for name in ['kinetic_energy', 'projected_range', 'csda_range', 'detour_factor', 'total_stopping_power']} 
 
@@ -70,9 +71,9 @@ class material:
             self.detour_factor = interp1d(
                 table['kinetic_energy'], table['detour_factor'], kind="cubic"
             )
-
-    def total_stopping_power( self,  xnew ): 
-        return splev( xnew, self.tck, der=0 )
+            self.total_stopping_power = interp1d(
+                table['kinetic_energy'], table['total_stopping_power'], kind="cubic"
+            )
 
     def read_table(self):
         data_file = open(data_path / self.tup.filename, "r")
@@ -83,10 +84,7 @@ class material:
                 self.table['projected_range'].append(float(columns[-2]) / self.density)
                 self.table['csda_range'].append(float(columns[-3]) / self.density)
                 self.table['detour_factor'].append(float(columns[-1]))
-                self.table['total_stopping_power'].append(float(columns[-4]) / self.density)
-#        self.tck = splrep(self.table['kinetic_energy'], self.table['total_stopping_power'], s=0)
-        self.tck = splrep(self.table['kinetic_energy'], self.table['total_stopping_power'] )
-
+                self.table['total_stopping_power'].append(float(columns[3]) / self.density)
 
     def find_material(self, name):
         "Return tuple for the material if name in the list of aliases"

--- a/pyrange/pyrange.py
+++ b/pyrange/pyrange.py
@@ -87,9 +87,9 @@ class material:
                 self.table['total_stopping_power'].append(float(columns[3]) / self.density)
 
     def find_material(self, name):
-        "Return tuple for the material if name in the list of aliases"
+        "Return tuple for the material if the name is in the list of aliases"
         for tup in registry:
             if name in tup.names:
                 return tup
-        print("ERROR: Mo material found in registry")
+        print("ERROR: Material not found in the registry")
         return ("None", 1, ["None"])


### PR DESCRIPTION
resolves #32 
reverted changes for total_stopping_power (back to interp1d)
added arbitrary materials argument to plots (example in README.md)
fixed test_plot_1, now the x points for interpolation plot are properly spaced (10 evenly spaced points between subsequent points in the table)